### PR TITLE
Get sbt package from scala.jfrog.io rather than bintray

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG SBT_VERSION=1.4.9
 RUN \
   mkdir /working/ && \
   cd /working/ && \
-  curl -L -o sbt-$SBT_VERSION.deb https://dl.bintray.com/sbt/debian/sbt-$SBT_VERSION.deb && \
+  curl -L -o sbt-$SBT_VERSION.deb https://repo.scala-sbt.org/scalasbt/debian/sbt-$SBT_VERSION.deb && \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
   apt-get update && \


### PR DESCRIPTION
See https://eed3si9n.com/bintray-to-jfrog-artifactory-migration-status-and-sbt-1.5.1

Fixes #22